### PR TITLE
docs: fix links on github pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,29 +32,31 @@ npm install holo-fn
 
 ## 📦 API Overview
 
-[API documentation can be found here](/docs/index.md)
+[API documentation can be found here](https://richecr.github.io/holo-fn/)
 
 ## 🧠 Examples
 
 ### Safe object access
 
 ```ts
-import { fromNullable } from 'holo-fn/maybe'
-import { pipe } from 'rambda'
+const double = (n: number) => n * 2;
 
-const getUserName = (user: any) =>
-  pipe(
-    fromNullable(user.profile),
-    m => m.chain(p => fromNullable(p.name)),
-    m => m.unwrapOr('Guest')
-  )(user)
+const result = pipe(
+  [5, 5, 6],
+  (ns) => fromNullable(head(ns)),
+  (x) => x.map(double),
+  M.matchM({
+    just: (n) => n,
+    nothing: () => -1
+  })
+);
+
+console.log(result); // 10
 ```
 
 ### Optional parsing
 
 ```ts
-import { fromNullable } from 'holo-fn/maybe'
-
 const parsePrice = (input: string) =>
   fromNullable(parseFloat(input))
     .map(n => (n > 0 ? n : null))

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,9 @@
 
 # 📚 holo-fn Documentation
 
-Welcome to the **holo-fn** documentation! This library is a minimal functional library for TypeScript, featuring monads like `Maybe`, `Either`, and `Result`.
+**A minimal functional library for TypeScript** featuring **monads** like `Maybe`, `Either` and `Result`. Built for composability and Rambda compatibility.
+
+> 💡 Designed to work seamlessly with `pipe` from Rambda. Fully typed, immutable, and safe by default.
 
 Below you will find detailed explanations, examples, and usage instructions to help you get started with **holo-fn**.
 
@@ -9,13 +11,14 @@ Below you will find detailed explanations, examples, and usage instructions to h
 
 ## ✨ Table of Contents
 
-- [Introduction](#introduction)
-- [Getting Started](#getting-started)
-- [API Reference](#api-reference)
-  - [Maybe](/docs/maybe/index.md)
-  - [Either](/docs/either/index.md)
-  - [Result](/docs/result/index.md)
-- [Contributing](#contributing)
+- [Introduction](#-introduction)
+- [Features](#-features)
+- [Getting Started](#-getting-started)
+- [API Reference](#-api-reference)
+  - [Maybe](/maybe)
+  - [Either](/either)
+  - [Result](/result)
+- [Contributing](#-contributing)
 
 ---
 
@@ -25,6 +28,17 @@ Below you will find detailed explanations, examples, and usage instructions to h
 
 - Designed to work seamlessly with `pipe` from `Rambda`.
 - Fully typed, immutable by default, and safe for modern TypeScript development.
+
+---
+
+## ✨ Features
+
+- ✅ Functional types: `Maybe`, `Either`, `Result`
+- ⚙️ Pipe-friendly (Rambda/Ramda compatible)
+- 🔒 Immutable by default
+- 🧪 100% test coverage
+- ⚡️ Zero dependencies
+- 🧠 Full TypeScript inference
 
 ---
 


### PR DESCRIPTION
This pull request updates the documentation and examples for the `holo-fn` library to improve clarity, usability, and alignment with its functional programming goals. Key changes include updating the API documentation link, enhancing the example code, and adding a new "Features" section to highlight the library's benefits.

### Documentation Updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L35-L57): Updated the API documentation link to point to the GitHub Pages site (`https://richecr.github.io/holo-fn/`) instead of a relative link.
* [`docs/index.md`](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L4-R21): Enhanced the introduction to emphasize the library's compatibility with Rambda, immutability, and safety. Added a new "Features" section to highlight key benefits like functional types, pipe-friendliness, and zero dependencies. [[1]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L4-R21) [[2]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6R34-R44)

### Example Code Improvements:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L35-L57): Replaced the "Safe object access" example with a more concise and functional example using `pipe`, `fromNullable`, and `matchM`. This better demonstrates the library's capabilities and integration with Rambda.