### PR TITLE
docs: use mkdocs-material

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,17 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - docs
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      - run: pip install mkdocs-material
+      - run: mkdocs gh-deploy --force

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ All notable changes to this project will be documented in [here](https://richecr
 
 ## 🤝 Contributing
 
-Please refer to [CONTRIBUTING.md](CONTRIBUTING.md) for instructions on how to run tests, build the library, and contribute.
+Please refer to [CONTRIBUTING.md](https://richecr.github.io/holo-fn/contributing) for instructions on how to run tests, build the library, and contribute.
 
 ## 📜 License
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,105 @@
+
+# Contributing to holo-fn
+
+Thank you for your interest in contributing to **holo-fn**! To keep things organized and make it easier for you to get involved, please read through the guidelines below.
+
+---
+
+## 🚀 Setup
+
+### 1. Install Dependencies
+
+To get started, clone the repository and install the dependencies:
+
+```bash
+git clone https://github.com/yourusername/holo-fn.git
+cd holo-fn
+npm install
+```
+
+### 2. Running Tests
+
+You can run the tests using Jest to ensure everything works as expected:
+
+```bash
+npm run test
+```
+
+### 3. Test Coverage
+
+To check test coverage:
+
+```bash
+npm run test:cov
+```
+
+---
+
+## 📦 Building
+
+To build the project:
+
+```bash
+npm run build
+```
+
+This will transpile the TypeScript code into JavaScript.
+
+---
+
+## 🧰 Testing Locally
+
+To test your changes locally before publishing or linking the library:
+
+1. Build the Library:
+
+  - Run the following to build the project and prepare the files for testing:
+  ```bash
+  npm run build
+  ```
+
+2. Pack the Library:
+
+  - After building, run npm pack to create a .tgz file that you can install locally:
+  ```bash
+  npm pack
+  ```
+
+3. Install Locally in Your Test Project:
+
+  - In the project where you want to test the library, run the following:
+  ```bash
+  npm install /path/to/holo-fn-<version>.tgz
+  ```
+
+  - This will install the library locally in your project, and you can import and use it as if it were an npm package.
+
+---
+
+## 🤝 How to Contribute
+
+1. **Fork the repository** to your GitHub account and clone it locally.
+2. **Create a new branch** for your feature or fix:
+   ```bash
+   git checkout -b feat/issue-number-or-short-description
+   ```
+3. **Make your changes**: add your feature or fix the bug.
+4. **Commit your changes**:
+   ```bash
+   git commit -am 'feat: add new feature'  # or 'fix: resolve issue'
+   ```
+5. **Push to your fork**:
+   ```bash
+   git push origin feat/issue-number-or-short-description
+   ```
+6. **Create a pull request** from your fork to the main repository.
+
+---
+
+## 🎯 Guidelines
+
+- Please **write clear commit messages**.
+- Ensure all code is **properly tested**.
+- Follow the **code style** used in the project.
+
+Thank you for contributing! 🚀

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,32 @@
+site_name: Holo-Fn
+site_description: A minimal functional library for TypeScript featuring monads like Maybe, Either and Result. Built for composability and Rambda compatibility.
+
+google_analytics:
+  - UA-72514911-3
+  - auto
+theme:
+  name: "material"
+  palette:
+    primary: indigo
+
+repo_name: richecr/holo-fn
+repo_url: https://github.com/richecr/holo-fn
+# edit_uri: ""
+
+nav:
+  - Introduction: "index.md"
+  - Getting Started: "index.md"
+  - Contributing: "contributing.md"
+  - Either:
+    - Overview: "either/index.md"
+  - Maybe:
+    - Overview: "maybe/index.md"
+  - Result:
+    - Overview: "result/index.md"
+
+markdown_extensions:
+  - admonition
+  - codehilite
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      linenums: true


### PR DESCRIPTION
This pull request introduces significant updates to documentation and deployment workflows for the `holo-fn` project. The changes include setting up automated documentation deployment, enhancing contribution guidelines, and configuring the MkDocs framework for improved documentation hosting.

### Documentation Deployment and Configuration:
* [`.github/workflows/publish-docs.yml`](diffhunk://#diff-dd751c654ce34c435239f846704cbba01f2aef90c73ad219db2d47789b369544R1-R17): Added a GitHub Actions workflow to automatically deploy documentation to GitHub Pages whenever changes are pushed to the `docs` branch. The workflow uses `mkdocs-material` for site generation.
* [`mkdocs.yml`](diffhunk://#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2R1-R32): Configured MkDocs with a Material theme, Google Analytics, and navigation for key sections like `Either`, `Maybe`, and `Result`. This ensures a structured and visually appealing documentation site.

### Documentation Enhancements:
* [`docs/contributing.md`](diffhunk://#diff-419d79ae7d440d49b3fa5fa7739f5f3a359e3ca42c3fa942e5604ae3474eb35bR1-R105): Added a comprehensive guide for contributors, including setup instructions, testing, building, and creating pull requests. This makes it easier for new contributors to get started.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L84-R84): Updated the link to the contribution guidelines to point to the hosted documentation site, improving accessibility.