### PR TITLE
feat: add filter method to Maybe and update documentation and tests

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "holo-fn-test",

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,5 +1,5 @@
 [test]
-
-coverageThreshold = { lines = 0.9, functions = 0.9, statements = 0.9 }
-
+coverage = true
+coverageSkipTestFiles = true
 coverageReporter  = ["text", "lcov"]
+coverageThreshold = { lines = 1.0, functions = 1.0, statements = 1.0, branches = 1.0 }

--- a/docs/maybe/index.md
+++ b/docs/maybe/index.md
@@ -40,6 +40,22 @@ const result2 = new Nothing<number>().chain((n) => new Just(n * 2));
 console.log(result2.unwrapOr(0)); // 0
 ```
 
+### `filter(fn: (value: T) => boolean): Maybe<T>`
+Filters the `Just` value based on a predicate. If the predicate returns `true`, keeps the value. If it returns `false`, converts to `Nothing`. Does nothing for `Nothing`.
+
+```ts
+import { Just, Nothing } from "holo-fn/maybe";
+
+const result1 = new Just(25).filter((n) => n >= 18);
+console.log(result1.unwrapOr(0)); // 25
+
+const result2 = new Just(15).filter((n) => n >= 18);
+console.log(result2.unwrapOr(0)); // 0
+
+const result3 = new Nothing<number>().filter((n) => n >= 18);
+console.log(result3.unwrapOr(0)); // 0
+```
+
 ### `unwrapOr(defaultValue: T): T`
 Returns the value of `Just`, or the default value for `Nothing`.
 
@@ -243,6 +259,56 @@ const result = pipe(
 );
 
 console.log(result); // true
+```
+
+---
+
+### `filter`
+
+Curried version of `filter` for `Maybe`. This allows filtering values in a functional pipeline based on a predicate.
+
+```ts
+import { filter, just, pipe } from 'holo-fn/maybe';
+
+const result = pipe(
+  just(25),
+  filter((x) => x >= 18),
+  filter((x) => x <= 100),
+  (res) => res.unwrapOr(0)
+);
+
+console.log(result); // 25
+```
+
+**Common use cases:**
+
+```ts
+// Validate age
+const validateAge = (age: number) =>
+  pipe(
+    just(age),
+    filter((x) => x >= 0),
+    filter((x) => x <= 150),
+    filter((x) => x >= 18)
+  );
+
+// Validate email format
+const validateEmail = (email: string) =>
+  pipe(
+    just(email),
+    filter((s) => s.length > 0),
+    filter((s) => s.includes('@')),
+    filter((s) => s.split('@')[1].includes('.'))
+  );
+
+// Parse positive integers
+const parsePositive = (input: string) =>
+  pipe(
+    just(input),
+    map((s) => parseInt(s, 10)),
+    filter((n) => !isNaN(n)),
+    filter((n) => n > 0)
+  );
 ```
 
 ---

--- a/docs/maybe/index.md
+++ b/docs/maybe/index.md
@@ -209,6 +209,58 @@ console.log(result); // 20
 
 ---
 
+### `filter`
+
+Curried version of `filter` for `Maybe`. This allows filtering values in a functional pipeline based on a predicate.
+
+```ts
+import { filter, just, pipe } from 'holo-fn/maybe';
+
+const result = pipe(
+  just(25),
+  filter((x) => x >= 18),
+  filter((x) => x <= 100),
+  (res) => res.unwrapOr(0)
+);
+
+console.log(result); // 25
+
+// Validate age
+const validateAge = (age: number) =>
+  pipe(
+    just(age),
+    filter((x) => x >= 0),
+    filter((x) => x <= 150),
+    filter((x) => x >= 18)
+  );
+
+console.log(validateAge(151).unwrapOr(0)); // 25
+
+// Validate email format
+const validateEmail = (email: string) =>
+  pipe(
+    just(email),
+    filter((s) => s.length > 0),
+    filter((s) => s.includes('@')),
+    filter((s) => s.split('@')[1]?.includes('.') ?? false)
+  );
+
+console.log(validateEmail('test@example.com').unwrapOr('Invalid email'));
+
+// Parse positive integers
+const parsePositive = (input: string) =>
+  pipe(
+    just(input),
+    map((s) => parseInt(s, 10)),
+    filter((n) => !isNaN(n)),
+    filter((n) => n > 0)
+  );
+
+console.log(parsePositive('42').unwrapOr(0)); // 42
+```
+
+---
+
 ### `unwrapOr`
 
 Curried version of `unwrapOr` for `Maybe`. This provides a cleaner way to unwrap the value in a `Maybe`.
@@ -263,52 +315,3 @@ console.log(result); // true
 
 ---
 
-### `filter`
-
-Curried version of `filter` for `Maybe`. This allows filtering values in a functional pipeline based on a predicate.
-
-```ts
-import { filter, just, pipe } from 'holo-fn/maybe';
-
-const result = pipe(
-  just(25),
-  filter((x) => x >= 18),
-  filter((x) => x <= 100),
-  (res) => res.unwrapOr(0)
-);
-
-console.log(result); // 25
-```
-
-**Common use cases:**
-
-```ts
-// Validate age
-const validateAge = (age: number) =>
-  pipe(
-    just(age),
-    filter((x) => x >= 0),
-    filter((x) => x <= 150),
-    filter((x) => x >= 18)
-  );
-
-// Validate email format
-const validateEmail = (email: string) =>
-  pipe(
-    just(email),
-    filter((s) => s.length > 0),
-    filter((s) => s.includes('@')),
-    filter((s) => s.split('@')[1].includes('.'))
-  );
-
-// Parse positive integers
-const parsePositive = (input: string) =>
-  pipe(
-    just(input),
-    map((s) => parseInt(s, 10)),
-    filter((n) => !isNaN(n)),
-    filter((n) => n > 0)
-  );
-```
-
----

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "bun run build.ts",
     "lint": "eslint",
-    "test": "bun test --coverage",
+    "test": "bun test",
     "coverage:html": "genhtml --output-directory coverage-html coverage/lcov.info"
   },
   "type": "module",

--- a/src/maybe/index.ts
+++ b/src/maybe/index.ts
@@ -4,6 +4,7 @@ export interface Maybe<T> {
 
   map<U>(fn: (value: T) => U): Maybe<U>;
   chain<U>(fn: (value: T) => Maybe<U>): Maybe<U>;
+  filter(fn: (value: T) => boolean): Maybe<T>;
   unwrapOr(defaultValue: T): T;
   match<U>(cases: { just: (value: T) => U; nothing: () => U }): U;
   equals(other: Maybe<T>): boolean;
@@ -28,6 +29,10 @@ export class Just<T> implements Maybe<T> {
 
   chain<U>(fn: (value: T) => Maybe<U>): Maybe<U> {
     return fn(this.value);
+  }
+
+  filter(fn: (value: T) => boolean): Maybe<T> {
+    return fn(this.value) ? this : new Nothing<T>();
   }
 
   unwrapOr(_: T): T {
@@ -66,6 +71,10 @@ export class Nothing<T = never> implements Maybe<T> {
     return new Nothing<U>();
   }
 
+  filter(_: (value: T) => boolean): Maybe<T> {
+    return this;
+  }
+
   unwrapOr(defaultValue: T): T {
     return defaultValue;
   }
@@ -97,6 +106,12 @@ export const chain =
   <T, U>(fn: (value: T) => Maybe<U>) =>
   (maybe: Maybe<T>): Maybe<U> => {
     return maybe.chain(fn);
+  };
+
+export const filter =
+  <T>(fn: (value: T) => boolean) =>
+  (maybe: Maybe<T>): Maybe<T> => {
+    return maybe.filter(fn);
   };
 
 export const unwrapOr =

--- a/tests/maybe.test.ts
+++ b/tests/maybe.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 import { pipe } from 'rambda';
-import { Just, Nothing, chain, equals, fromNullable, just, map, match, nothing, unwrapOr } from '../src/maybe';
+import { Just, Nothing, chain, equals, filter, fromNullable, just, map, match, nothing, unwrapOr } from '../src/maybe';
 
 describe('Maybe', () => {
   it('Just.isJust() should return true', () => {
@@ -41,6 +41,36 @@ describe('Maybe', () => {
   it('Nothing.chain() should return other Nothing', () => {
     const result = new Nothing<number>().chain((x) => new Just(x * 2));
     expect(result.isNothing()).toBe(true);
+  });
+
+  it('should keep Just value when predicate returns true', () => {
+    const result = new Just(10).filter((x) => x > 5);
+    expect(result.isJust()).toBe(true);
+    expect(result.unwrapOr(0)).toBe(10);
+  });
+
+  it('should convert Just to Nothing when predicate returns false', () => {
+    const result = new Just(3).filter((x) => x > 5);
+    expect(result.isNothing()).toBe(true);
+    expect(result.unwrapOr(0)).toBe(0);
+  });
+
+  it('should keep Nothing as Nothing regardless of predicate', () => {
+    const result = new Nothing<number>().filter((x) => x > 5);
+    expect(result.isNothing()).toBe(true);
+  });
+
+  it('should filter with multiple conditions', () => {
+    const result = new Just(25).filter((x) => x >= 18).filter((x) => x <= 100);
+    expect(result.unwrapOr(0)).toBe(25);
+  });
+
+  it('should filter with regex pattern', () => {
+    const result1 = just('abc123').filter((s) => /^[a-z]+$/.test(s));
+    expect(result1.isNothing()).toBe(true);
+
+    const result2 = just('abc').filter((s) => /^[a-z]+$/.test(s));
+    expect(result2.unwrapOr('')).toBe('abc');
   });
 
   it('match should dispatch to correct branch', () => {
@@ -129,6 +159,64 @@ describe('Maybe - Curried Helpers', () => {
       unwrapOr(0)
     );
     expect(result).toBe(0);
+  });
+
+  it('should work with curried filter in pipe', () => {
+    const result = pipe(
+      just(42),
+      filter((x) => x > 0),
+      filter((x) => x % 2 === 0),
+      unwrapOr(0)
+    );
+    expect(result).toBe(42);
+  });
+
+  it('should filter and map together in pipe', () => {
+    const result = pipe(
+      just(5),
+      filter((x) => x > 0),
+      map((x) => x * 2),
+      filter((x) => x > 5),
+      unwrapOr(0)
+    );
+    expect(result).toBe(10);
+  });
+
+  it('should handle complex filtering scenarios', () => {
+    const validateAge = (age: number) =>
+      just(age)
+        .filter((x) => x >= 0)
+        .filter((x) => x <= 150)
+        .filter((x) => x >= 18);
+
+    expect(validateAge(25).unwrapOr(0)).toBe(25);
+    expect(validateAge(15).unwrapOr(0)).toBe(0);
+    expect(validateAge(-5).unwrapOr(0)).toBe(0);
+    expect(validateAge(200).unwrapOr(0)).toBe(0);
+  });
+
+  it('should filter objects by properties', () => {
+    const user = { name: 'John', age: 30 };
+    const result = just(user)
+      .filter((u) => u.age >= 18)
+      .filter((u) => u.name.length > 0);
+    expect(result.unwrapOr({ name: '', age: 0 })).toEqual(user);
+  });
+
+  it('should use curried filter with fromNullable', () => {
+    const parsePositive = (input: string | null) =>
+      pipe(
+        fromNullable(input),
+        map((s) => parseInt(s, 10)),
+        filter((n) => !isNaN(n)),
+        filter((n) => n > 0),
+        unwrapOr(0)
+      );
+
+    expect(parsePositive('42')).toBe(42);
+    expect(parsePositive('-5')).toBe(0);
+    expect(parsePositive('abc')).toBe(0);
+    expect(parsePositive(null)).toBe(0);
   });
 
   it('should unwrapOr with default value using curried unwrapOr', () => {


### PR DESCRIPTION
This pull request introduces a new `filter` method to the `Maybe` type, enabling value filtering based on predicates for both object-oriented and functional/curried usage. The change is thoroughly documented and tested, and includes updates to configuration and scripts for improved test coverage requirements.

### Maybe type enhancements

* Added a `filter(fn: (value: T) => boolean): Maybe<T>` method to the `Maybe` interface, with implementations for both `Just` and `Nothing`. This allows filtering values in a `Maybe`, returning `Nothing` if the predicate fails. [[1]](diffhunk://#diff-67c2079166ce992cc9a136f3d4cdd8e5cfa0f1ca887233d9cce441cd70f2f829R7) [[2]](diffhunk://#diff-67c2079166ce992cc9a136f3d4cdd8e5cfa0f1ca887233d9cce441cd70f2f829R34-R37) [[3]](diffhunk://#diff-67c2079166ce992cc9a136f3d4cdd8e5cfa0f1ca887233d9cce441cd70f2f829R74-R77)
* Introduced a curried `filter` helper for functional pipelines, enabling easy composition with other `Maybe` helpers.

### Documentation improvements

* Expanded the documentation in `docs/maybe/index.md` to explain and provide examples for the new `filter` method and its curried usage. Includes common use cases like validation and parsing. [[1]](diffhunk://#diff-bf699b1cc8548dd4574b6ddf16fe8b743756181de1efe80dc4d56e206bf46ca9R43-R58) [[2]](diffhunk://#diff-bf699b1cc8548dd4574b6ddf16fe8b743756181de1efe80dc4d56e206bf46ca9R265-R314)

### Testing

* Added comprehensive tests for the new `filter` functionality, covering direct usage, chaining, curried pipelines, and various scenarios. [[1]](diffhunk://#diff-59451db6f75e440ad6a2a0cd76069dbf8eef3a6a2e8cbee9269eeba77d40c1c1R46-R75) [[2]](diffhunk://#diff-59451db6f75e440ad6a2a0cd76069dbf8eef3a6a2e8cbee9269eeba77d40c1c1R164-R221)

### Configuration and scripts

* Updated `bunfig.toml` to require 100% coverage for lines, functions, statements, and branches, and to skip test files from coverage calculations.
* Adjusted the test script in `package.json` to run tests without the coverage flag, since coverage is now controlled via config.